### PR TITLE
fix: improve size formatting and analysis output

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,2 +1,3 @@
 pub mod file_operations;
 pub mod hashing;
+pub mod formatting;

--- a/src/utils/formatting.rs
+++ b/src/utils/formatting.rs
@@ -1,0 +1,16 @@
+/// Convert bytes to human readable string with appropriate unit
+pub fn format_size(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    if bytes >= GB {
+        format!("{:.2} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
+}


### PR DESCRIPTION
- Add format_size utility for human-readable sizes
- Add explicit handling for null size values in DataFrames
- Keep raw bytes in CSV output for better analysis
- Fix total folder size unit display